### PR TITLE
Fix installation instructions in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Unofficial but [officially accepted](https://docs.esa.io/posts/158) [esa](https:
 Alternatively, if you use [Homebrew](http://brew.sh/), you can install via:
 
 ```bash
-$ brew cask install quail
+$ brew install --cask quail
 ```
 
 ### Windows


### PR DESCRIPTION
Fix error when installing using latest Homebrew in macOS. This is not a bug of this app, but readme needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103164348-7e163b80-484d-11eb-9acf-bbe58a27eea6.png)
